### PR TITLE
update precloud version

### DIFF
--- a/.version-change-type
+++ b/.version-change-type
@@ -1,1 +1,1 @@
-major
+patch

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 Initial release
+Update @tinystacks/precloud dev dependency version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@tinystacks/aws-cdk-parser",
-  "version": "0.0.2",
+  "version": "0.0.3-local.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinystacks/aws-cdk-parser",
-      "version": "0.0.2",
+      "version": "0.0.3-local.0",
       "license": "ISC",
       "devDependencies": {
-        "@tinystacks/precloud": "^1.0.2",
+        "@tinystacks/precloud": "^1.0.3",
         "@types/jest": "^28.1.7",
         "@types/node": "^18.11.15",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -51,6 +51,1812 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+      "integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.257.0.tgz",
+      "integrity": "sha512-/K5kLqZa8xrkk8ueLOdnHKZJxI0dp8J9X39y8B2zfJSqSb+n8ETqt0zo8kFcsn+JG746YyMby3t05YKCI5KLmg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.257.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.257.0.tgz",
+      "integrity": "sha512-3dNY1S7tOi0g49mxpZh2pvmnVXhRFLOLbQLMyairOuCbhMespSwc0/enwvX2j0lQUtCQF6nVi00oYHmhdJ/5RA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.257.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.257.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.257.0.tgz",
+      "integrity": "sha512-Wft59x+DpiZOtjWNeD0YdQYz5GIwn2IZP4oMAnq8hBhoUJUYgN2wG+PZeUAIpaCKFWwCg+oHgj3vRclzXAnTSg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "3.0.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.257.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/eventstream-serde-browser": "3.257.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.257.0",
+        "@aws-sdk/eventstream-serde-node": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-blob-browser": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/hash-stream-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/md5-js": "3.257.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-expect-continue": "3.257.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-location-constraint": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-sdk-s3": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-ssec": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4-multi-region": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-stream-browser": "3.257.0",
+        "@aws-sdk/util-stream-node": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.257.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-service-quotas/-/client-service-quotas-3.257.0.tgz",
+      "integrity": "sha512-yjdlS6KRqh6krLXdpQyVu69PUx5gjHGYXziciWkEr+BgzNn8SPXLD/Z1YX82Zu+AMdgzRJJ4891uVDHa7KbfVw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.257.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.257.0.tgz",
+      "integrity": "sha512-3GzXBwARYiIo0Y4S5Z9vz41g2YekZ1gUefg0NaJlGXwBxcj5aRlVzImUM+kI1FM24L8treZeJTum7rT4naUNNQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.257.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/md5-js": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.257.0.tgz",
+      "integrity": "sha512-sD0yTTctLbjDoSV3hJem+xz9BzusmkkU/4Fts9gEs4C5NjS0YrfPAvQWE++yRzPLPR/dMhDFVCOs7voTzUhUWQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.257.0.tgz",
+      "integrity": "sha512-yXf53Zc7DYt/4j7xGXgWaDVhE/XMDLoid5l8bOb4aDJN6kxgl5bXV/sH3DwND/fA09EQHU1W+9oe/8InVqsliw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.257.0.tgz",
+      "integrity": "sha512-AVNngoDGACR7xs9wTU7hrZSvMfNOGvWP/B/ieA0au3H3KDucjCZzBd3j2vYkR6Cph9dY7YkpU2Gtzn+JXD0b1g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.257.0",
+        "@aws-sdk/middleware-sdk-sts": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.257.0",
+        "@aws-sdk/util-defaults-mode-node": "3.257.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.257.0.tgz",
+      "integrity": "sha512-jChjr8ayaXoAcUgrRr+JRIJ6bPtEoS+/xW9khpHOmrEX+uBJ7xLPfdS4e6nmxAQpbem9AsUVvf57DXhSh5/nLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.257.0.tgz",
+      "integrity": "sha512-KNXKB4llqDpUwxeOMIcOSL4BSklaClOctERDnmShN2h4gS9lgHN8dWQOuEqd0YkBVDtOg//tz0GeS5tsZsL5dA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+      "integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.257.0.tgz",
+      "integrity": "sha512-UrxYkHWndy6s/bZZWH2poIyqdISTbILGTcK9tT8cFaUUrNIEFXiVESZMNNaagy0Dyy9wr80ndumxRkutYga9VA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.257.0.tgz",
+      "integrity": "sha512-69jW9/Os2zGBATQR8Urde+IlzicgJPCO/gAWpm4AYJYT5LSGc0pOuZflSXq+ZfKy3jcSoN0yOFxkoMnmZb8pzg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.257.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.257.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.257.0.tgz",
+      "integrity": "sha512-yXVNOml/w4ipWiRgLWUphGwISqJQRPjALgTsRa0O+CzpaEc/0HRqM8I78VzCzjsb+QE4EP7MZej6tkEAZYgTlg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.257.0",
+        "@aws-sdk/credential-provider-ini": "3.257.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.257.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+      "integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.257.0.tgz",
+      "integrity": "sha512-I/1TQm6WruqxTTPH+Wo2o+YCLenEY0bWq97EQn+d8Cp0N7cNJUDt8BHF22dQtUzd7bvSspVK5M4qCZKAh3fhOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/token-providers": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+      "integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.257.0.tgz",
+      "integrity": "sha512-A2bl5M7BlcV94H4rgdYnWRcnQxVARkrWSNQzA1n/wJY3EPXkFN0/Rjie/W7j7hXVtjRVaALSGVNwxQ/BQ7ZMTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.257.0",
+        "@aws-sdk/client-sso": "3.257.0",
+        "@aws-sdk/client-sts": "3.257.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.257.0",
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.257.0",
+        "@aws-sdk/credential-provider-ini": "3.257.0",
+        "@aws-sdk/credential-provider-node": "3.257.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.257.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.257.0.tgz",
+      "integrity": "sha512-ji+lRLpv2qhrX8NhYeoP1YqHxB147L/SnSIeBE5QNzbvYohmOGUBbCJYDsj65qzG2ba+nopnPQj8gNbB6l7M+A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.257.0.tgz",
+      "integrity": "sha512-pReHeVygoezysk8nztDptUzHz0uxo9TodVWz+9kc4Zn1SPIcNZlqOaiza87Cy5DrQ7oLVGtNY28+Q1qkiVncwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.257.0.tgz",
+      "integrity": "sha512-YbUETgkcFqPJmwcBozHbx3Xloh7mPk9SunNB+Ndy8egwV3L/jNZnEzZnPOtWbD10AXSuJvSbGQ8+l4FblRqZqw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.257.0.tgz",
+      "integrity": "sha512-lQIsGhX1YC6CSf4wP+jsnaNi7tNLJs9qLJzbUfFVFjZgdAP3logOWE5hFojmgjoxHJWcLtP7LOGoOD8WU+y1Fw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.257.0.tgz",
+      "integrity": "sha512-WJ657NfbgMjqgLKnwUMC1+zmx1xQ9G9NIPpdWF/vKKqxohas3pQopC3FD9gydQQbI5KoUktmmmlNO6bsQkXBlw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+      "integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-blob-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.257.0.tgz",
+      "integrity": "sha512-3Nrcci3pCCc0ZILMGa/oUMq9le6nhvgCoVxFy5skYs/mQu4QnA8HcK0u4bTueW41rBj0ZW6BHLk/2SmigIkjCQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+      "integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-stream-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.257.0.tgz",
+      "integrity": "sha512-A24+EI0sO+IYO78sQPY4vVx7vzToc6XAobQqowmBJ6GXXILK72d3MR3NVbm0lmcS4Dh6MVZEFQD/DCyKvj2C7g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+      "integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.257.0.tgz",
+      "integrity": "sha512-bNrvhztmVPukiV46zv5dJo5RZ6WxYqcuzHSFmhDVdglrGtcKOZKzr/QIm62XvW/1N46QY0ukMqlnAAzAzYNUdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.257.0.tgz",
+      "integrity": "sha512-DRL8EWVS9eA7zcW6yGfJN+rT9eEjorOa3nRB8MNa6IwE8a6Qx8/oKz2CowCEBeDYOl09JEeLn41UXQ4ua3Mz6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+      "integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.257.0.tgz",
+      "integrity": "sha512-RQNQe/jeVuWZtXXfcOm+e3qMFICY6ERsXUrbt0rjHgvajZCklcrRJgxJSCwrcS7Le3nl9azFPMAMj9L7uSK28g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.257.0.tgz",
+      "integrity": "sha512-7HSRA2Ta0fTq9Ewznp6fYG7CYOoqr5TeqEhKL1HyFb5i6YmsCiz88JKNJTllD5O7uFcd7Td/fJ66pK4JttfaaQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.257.0.tgz",
+      "integrity": "sha512-bIzdqUdS1KoYVeEijdL5HcGdjmcZYzLPE6bG7MfOdrxVsM5SOHFZTRuqi++dXKDZ+DcWiGP45Pcm+60jAsk97g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-crypto/crc32c": "3.0.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+      "integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.257.0.tgz",
+      "integrity": "sha512-pmm5rJR5aatXG0kC0KPBxkgoNn/ePcyVIYHGMEuJXRJm3ENy569QAH9UZeMFjprp3uuAbkqItQbY3MP8TYvuYA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+      "integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+      "integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.257.0.tgz",
+      "integrity": "sha512-vDOy4PbSRW2gtgoJZ+yvgyxdlTwbZGpuv/rA2+XYxURmhPMzpmqs4o1DR37LG8O41WouI1rPzA7E+Ffo+iNWjw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.257.0.tgz",
+      "integrity": "sha512-3U5qb5UzE6ch/ufNjbdkEpJxvoAP/hw2+Dio6JPFDVZ7IXMQCs4qTQLgIm7aUeB7bjpFnc27wn/Feo7tFwTA1A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-endpoint": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-format-url": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.257.0.tgz",
+      "integrity": "sha512-l9KRlUgsDKV1MB3zfttX/syhIBsG5Z3VVslz6EW09eSqZVreCudW3TMdyeLemup57xC2veEpkgVj8igiXd/LVQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.257.0.tgz",
+      "integrity": "sha512-NXdaAmHmFqNtP78NuyzPmUqCd2rCLLZnYxaU4SKSX+OpBpfwHX2sIBJlvKm7rGFH1txI7Zk3O8UkTxKGZe9W1Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+      "integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+      "integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+      "integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.257.0.tgz",
+      "integrity": "sha512-YcZrKeZk/0bsFvnTqp2rcF+6BSmeLTA65ZtyNNP2hh7Imaxg3kAQcueOJBeK4YP/5nU7a1mtt/4Q8BqbIjc41g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+      "integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+      "integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.257.0.tgz",
+      "integrity": "sha512-IfGF7+cU0PyB7RpHlgc445ZAUZDWn4ij2HTB6N+xULwFw2TxnyQ2tvo3Gp5caW9VlJ3eXE9wFrynv+JXUIH7Bg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+      "integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+      "integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+      "integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+      "integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+      "integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+      "integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+      "integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+      "integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.257.0.tgz",
+      "integrity": "sha512-4ZyJp6my6F6R8jG+zlIR+Sw3W2vZcBTcpzAnSAHI0UBWjx5/buiKU5QY7oj29H3pESDD7DovZinD7TtHvMNoZw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.257.0.tgz",
+      "integrity": "sha512-Vy/en+llpslHG6WZ2yuN+On6u7p2hROEURwAST/lpReAwBETjbsxylkWvP8maeGKQ54u9uC6lIZAOJut2I3INw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.257.0.tgz",
+      "integrity": "sha512-Ysd1dpWiI2oBOrJpkSJkgPsY0dwMtavIBzF3d5JYN1HCl14Aqc2jcNqBjD+7nEeL6CHXcFeyB7jmCDqiuP0V3A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+      "integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+      "integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.257.0.tgz",
+      "integrity": "sha512-nkfK+MNacVd3Px/fcAvU0hDeh+r7d+RLLt3sJ5Zc0gGd+i3OQEP58V8QzR9PYMvUvSvGQP16fQVQHSbRZtuWyQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.257.0.tgz",
+      "integrity": "sha512-qsIb7aPbGFcKbBGoAQmlzv1gMcscgbpfrRh4rgNqkJXVbJ52Ql6+vXXfBmlWaBho0fcsNh5XnYu1fzdCuu+N7g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+      "integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.257.0.tgz",
+      "integrity": "sha512-Q/c1BLoEZLvnjagAE0nQryhQlFoC/a8ZrXJn4XljWPeFcFAVLpCoSzcTbQM1N4oQvDIgMvl5gBeGzp0BiW30QA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+      "integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+      "integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.257.0.tgz",
+      "integrity": "sha512-UAfoqv9tzIjQhV0w8NmvmWISB8teZJnSnJiLocJnmxz2cR7Mz6bTDrFYedi6pjROeGaKqZywVqBD+9hJZwI26A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.257.0.tgz",
+      "integrity": "sha512-UlLEerQCNejNulYmGXm/4X463n8n21foA2d6kgJ4AUSMWWhoRBjfwrM4gI7tA30zh9U81d6xbUtoOQTqKVtMTw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+      "integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.257.0.tgz",
+      "integrity": "sha512-fOHh80kiVomUkABmOv3ZxB/SNLnOPAja7uhQmGWfKHXBkcxTVfWO2KBs5vzU5qhVZA0c1zVEvZPcBdRsonnhlw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.257.0.tgz",
+      "integrity": "sha512-Fr6of3EDOcXVDs5534o7VsJMXdybB0uLy2LzeFAVSwGOY3geKhIquBAiUDqCVu9B+iTldrC0rQ9NIM7ZSpPG8w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -572,6 +2378,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cdktf/hcl2json": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.15.1.tgz",
+      "integrity": "sha512-iH+V9ay2R+q5u4sl79ztiB1eTAvjlVBgh/4YkPEK5KqvFYdKY677pWEfWqoX92JuH2dW77bfcXnJJwQYAZCxuA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node-fetch": "^2.6.2",
+        "fs-extra": "^8.1.0",
+        "node-fetch": "^2.6.7"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
@@ -1556,18 +3374,96 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@tinystacks/aws-cdk-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tinystacks/aws-cdk-parser/-/aws-cdk-parser-0.0.2.tgz",
+      "integrity": "sha512-NSdHt/WS6B5RepqNxXmLMHqML0kxqZBkUyupIU3OobBcZmMrF8hLhhGbZ8h336MVVTNljdju8hDJVHZMfVuOrg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "husky": "^8.0.3"
+      }
+    },
+    "node_modules/@tinystacks/aws-resource-checks": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/aws-resource-checks/-/aws-resource-checks-0.0.1.tgz",
+      "integrity": "sha512-sluSNFDULt6p7WrByUORTxjecShOEe/oh8L5waQ/PgPNLrTrg4YFN740IJft16lLztiASpI6WlD5LlAe9EQG7w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.252.0",
+        "@aws-sdk/client-sqs": "^3.252.0",
+        "@aws-sdk/credential-providers": "^3.252.0",
+        "husky": "^8.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1"
+      }
+    },
+    "node_modules/@tinystacks/aws-template-checks": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/aws-template-checks/-/aws-template-checks-0.0.1.tgz",
+      "integrity": "sha512-HqKltfJs/ykgIlgtziacmVUPohpNPLaWHUSs8QjInP0oAiGjl/CmPSk4uJTERWedzDpYvDAwYEKpRJmogyIkpQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-ec2": "^3.252.0",
+        "@aws-sdk/client-s3": "^3.252.0",
+        "@aws-sdk/client-service-quotas": "^3.252.0",
+        "@aws-sdk/credential-providers": "^3.252.0",
+        "husky": "^8.0.3"
+      }
+    },
     "node_modules/@tinystacks/precloud": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tinystacks/precloud/-/precloud-1.0.2.tgz",
-      "integrity": "sha512-ldxewz8cM+2PhcDHh3HSTJHgMgSWcjGDKZx1kmmVZfaAPvfZeBVr7NnLyMiGjWw/PNUyrp39rT1vgEoCfGY75g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tinystacks/precloud/-/precloud-1.0.3.tgz",
+      "integrity": "sha512-gOtwLhvSupvz37056d3TshgfA6KJ1kXKQVxKlIRC2rpVghZyfZpNWVbR/Z0YnU9hy4Cic+yJV+aAOLbUEZngwQ==",
       "dev": true,
       "dependencies": {
         "colors": "^1.4.0",
         "commander": "^10.0.0",
+        "husky": "^8.0.3",
         "lodash.isnil": "^4.0.0"
       },
       "bin": {
         "precloud": "dist/index.js"
+      },
+      "peerDependencies": {
+        "@tinystacks/aws-cdk-parser": "0.x",
+        "@tinystacks/aws-resource-checks": "0.x",
+        "@tinystacks/aws-template-checks": "0.x",
+        "@tinystacks/terraform-module-parser": "0.x",
+        "@tinystacks/terraform-resource-parser": "0.x"
+      }
+    },
+    "node_modules/@tinystacks/terraform-module-parser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/terraform-module-parser/-/terraform-module-parser-0.0.1.tgz",
+      "integrity": "sha512-jL4aTzhH7Ode6jba5oRKTL5e5GSGXelP0CPWwxuPUdi0hKhq6LWTACR33e5rJbYW7b2QeVANeLYeUSHEVswK1Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@cdktf/hcl2json": "^0.15.0",
+        "cached": "^6.1.0",
+        "lodash.get": "^4.4.2",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "node_modules/@tinystacks/terraform-resource-parser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tinystacks/terraform-resource-parser/-/terraform-resource-parser-0.0.1.tgz",
+      "integrity": "sha512-N3zCuQH92MOEfVlSHR9F4lP2Yz5NCKV7FVZmt7q+Vv8+4f0YMFlzigdiC6c2UFEYgFRF9sR67BF3Amcl/fJplQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@cdktf/hcl2json": "^0.15.0",
+        "cached": "^6.1.0",
+        "husky": "^8.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1677,6 +3573,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2150,6 +4057,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -2338,6 +4252,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2414,6 +4342,20 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/cached": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cached/-/cached-6.1.0.tgz",
+      "integrity": "sha512-1zFJAmD0QibGJB2+mq9SEz4tYuu+u4oKd3oG/626hzAigvmer4RX8FpytfpE4+hEMgpHdRV3jtXKq/dPoE4KzQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "memcached-elasticache": "^1.1.1",
+        "redis": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -2599,6 +4541,19 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
@@ -2613,6 +4568,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
@@ -2711,6 +4673,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depcheck": {
@@ -3594,6 +5576,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -3678,6 +5677,36 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4002,6 +6031,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
       }
     },
     "node_modules/html-escaper": {
@@ -4543,6 +6583,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackpot": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+      "integrity": "sha512-rbWXX+A9ooq03/dfavLg9OXQ8YB57Wa7PY5c4LfU3CgFpwEhhl3WyXTQVurkaT7zBM5I9SSOaiLyJ4I0DQmC0g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "retry": "0.6.0"
       }
     },
     "node_modules/jest": {
@@ -6186,6 +8236,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6244,6 +8304,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
@@ -6255,6 +8322,20 @@
       "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
       "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -6337,6 +8418,29 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/memcached": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+      "integrity": "sha512-lHwUmqkT9WdUUgRsAvquO4xsKXYaBd644Orz31tuth+w/BIfFNuJMWwsG7sa7H3XXytaNfPTZ5R/yOG3d9zJMA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "hashring": "3.2.x",
+        "jackpot": ">=0.0.6"
+      }
+    },
+    "node_modules/memcached-elasticache": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/memcached-elasticache/-/memcached-elasticache-1.1.1.tgz",
+      "integrity": "sha512-jPPgHzuGDBQqgDGTe16sIYV09G3Ch/MjI51ZDA4xcIhmdWrRsOYvSZn9OboeRV8pvEr74x1D3ty0GZVwCP+nKA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "lodash": "^4.17.4",
+        "memcached": "^2.2.2"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6363,6 +8467,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -6443,6 +8570,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -6929,6 +9077,56 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -7027,6 +9225,16 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+      "integrity": "sha512-RgncoxLF1GqwAzTZs/K2YpZkWrdIYbXsmesdomi+iPilSzjUyr/wzNIuteoTVaWokzdwZIJ9NHRNQa/RUiOB2g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/reusify": {
@@ -7200,6 +9408,13 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7375,6 +9590,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -7530,6 +9752,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/ts-jest": {
       "version": "28.0.8",
@@ -7709,6 +9938,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -7744,6 +9983,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -7765,6 +10014,24 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinystacks/aws-cdk-parser",
-  "version": "0.0.2",
+  "version": "0.0.3-local.0",
   "description": "",
   "main": "dist/index.js",
   "files": [
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/tinystacks/aws-cdk-parser#readme",
   "devDependencies": {
-    "@tinystacks/precloud": "^1.0.2",
+    "@tinystacks/precloud": "^1.0.3",
     "@types/jest": "^28.1.7",
     "@types/node": "^18.11.15",
     "@typescript-eslint/eslint-plugin": "^5.33.1",


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Non-bug Patch (i.e. dependency update, cicd update, etc.)

## Link to Notion Task or Github Issue
<!-- Go to the task, press the ellipsis button (three dots), then click Copy Link -->
<!-- Example: -->
<!-- https://www.notion.so/tinystacks/Add-Linter-to-Templates-6b4b1910281842308c11d14961d01237 -->

## Summary of Changes(s)
<!-- Example: -->
<!--
1. Add eslint rules via `.eslintrc` file
2. Add scripts in `package.json` to run linter and linter with fix flag
3. Add `npm run lint` to github action workflow
4. Fix existing linting errors
-->
Update precloud to 1.0.3